### PR TITLE
Remove NSLog import

### DIFF
--- a/classDump.cy
+++ b/classDump.cy
@@ -1,5 +1,3 @@
-@import org.cycript.NSLog;
-
 // *** Symbols loading ****
 
 NSTemporaryDirectory_ = dlsym(RTLD_DEFAULT, "NSTemporaryDirectory");
@@ -282,7 +280,7 @@ function loadFZBundler() {
         var enumerator = [ObjectiveC.classes keyEnumerator];
         while ((name = [enumerator nextObject])) {
             let hasPrefix = prefix == null || [name hasPrefix:prefix];
-            let isBundle = [[NSBundle bundleForClass:objc_getClass(name)] 
+            let isBundle = [[NSBundle bundleForClass:objc_getClass(name)]
                             isEqual:bundle];
 
             if (isBundle && hasPrefix && !_classIsInternal(name)) {


### PR DESCRIPTION
## Why

As of the newer versions of cycript, this import is no longer necessary
(and it actually throws an error).
## Why you may not want to merge this

If you're using older versions of cycript, calls to `NSLog` won't work without this. I'm kind of assuming people using a script like this for cycript will be willing to update though.
